### PR TITLE
Add MBeanNameGenerator and associated configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ kamon.jmx {
     http-server     = [ "**" ]
     kamon-mxbeans   = [ "**" ]
   }
+  mbean-name-generator = kamon.jmx.SimpleMBeanNameGenerator
 }
 ```
 
@@ -162,6 +163,7 @@ kamon {
       # Here is the addition of the JMX exporting functionality to the subscriptions
       kamon-mxbeans   = [ "**" ]
     }
+    mbean-name-generator = kamon.jmx.SimpleMBeanNameGenerator
   }
 
   # adding the JMX to Kamon module

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -19,6 +19,7 @@ kamon {
       http-server     = [ "**" ]
       kamon-mxbeans   = [ "**" ]
     }
+    mbean-name-generator = kamon.jmx.SimpleMBeanNameGenerator
   }
 
   modules {

--- a/src/main/scala/kamon/jmx/JMXReporterActor.scala
+++ b/src/main/scala/kamon/jmx/JMXReporterActor.scala
@@ -173,7 +173,7 @@ private object JMXReporterActor {
   import MBeanManager._
   import MetricMBeans._
 
-  private[jmx] def props = Props(classOf[JMXReporterActor])
+  private[jmx] def props(mBeanNameGenerator: MBeanNameGenerator) = Props(new JMXReporterActor(mBeanNameGenerator))
 
   private def updateHystogramMetrics(group: String, name: String, hs: Histogram.Snapshot): Unit = {
     createOrUpdateMBean[HistogramMetric, Histogram.Snapshot](group, name, hs)
@@ -184,7 +184,7 @@ private object JMXReporterActor {
   }
 }
 
-private class JMXReporterActor extends Actor {
+private class JMXReporterActor(mBeanNameGenerator: MBeanNameGenerator) extends Actor {
 
   import JMXReporterActor._
   import MBeanManager.unregisterAllBeans
@@ -197,9 +197,9 @@ private class JMXReporterActor extends Actor {
       } {
         metricSnapshot match {
           case hs: Histogram.Snapshot ⇒
-            updateHystogramMetrics(entity.category, entity.name + "." + metricKey.name, hs)
+            updateHystogramMetrics(entity.category, mBeanNameGenerator.generateName(entity, metricKey), hs)
           case cs: Counter.Snapshot ⇒
-            updateCounterMetrics(entity.category, entity.name + "." + metricKey.name, cs)
+            updateCounterMetrics(entity.category, mBeanNameGenerator.generateName(entity, metricKey), cs)
         }
       }
   }

--- a/src/main/scala/kamon/jmx/MBeanNameGenerator.scala
+++ b/src/main/scala/kamon/jmx/MBeanNameGenerator.scala
@@ -1,0 +1,13 @@
+package kamon.jmx
+
+import kamon.metric.{ Entity, MetricKey }
+
+trait MBeanNameGenerator {
+  def generateName(entity: Entity, metricKey: MetricKey): String
+}
+
+class SimpleMBeanNameGenerator extends MBeanNameGenerator {
+  override def generateName(entity: Entity, metricKey: MetricKey) = {
+    entity.name + "." + metricKey.name
+  }
+}


### PR DESCRIPTION
This PR allows to use a specific `MBeanNameGenerator` implementation that will be used to generate the name of the MBeans.
It comes with a new config key and a default implementation that generates names in the same way as the actual code.

I needed this feature to be able to prefix trace-segment metrics with the trace name in order to have them contextualised (these metrics are currently exported only with the segment name).

I don't know if it's relevant, but I can also add the implementation of the name generator that prefixes segment name with trace name in this PR.